### PR TITLE
Replaced FIRST's Mecanum Class with our own, Modified Lambda Joystick

### DIFF
--- a/src/main/java/frc/robot/LambdaJoystick.java
+++ b/src/main/java/frc/robot/LambdaJoystick.java
@@ -54,7 +54,9 @@ public class LambdaJoystick extends Joystick {
                 buttons[i].listen(this.getRawButton(i + 1));
             }
         }
-        joystickListener.accept(new ThrottlePosition(buffer(getX()), buffer(getY()), buffer(getZ())));
+
+        System.out.println("x: " + buffer(getX()) + ",\ty: " + buffer(getY()) + ",\tz: " + buffer(getZ()) + ",\ttwist: " + buffer(getTwist()) + ",\tthrottle: " + buffer(getThrottle()));
+        joystickListener.accept(new ThrottlePosition(buffer(getX()), buffer(getY()), buffer(getZ()), buffer(getThrottle())));
     }
 
     /**
@@ -104,7 +106,16 @@ public class LambdaJoystick extends Joystick {
      * Throttle Position holds doubles x, y, and z representing the location of the throttle and dial.
      */
     public static class ThrottlePosition {
-        public final double x, y, z;
+        public final double x, y, z, w;
+
+        /**
+         * Create a Throttle position given a (x, y) position of the joystick throttle.
+         * @param x The right left position of the joystick (1 to -1).
+         * @param y The vertical position of the joystick, 1 forwards, -1 is backwards (1 to -1).
+         */
+        public ThrottlePosition(final double x, final double y) {
+            this(x, y, 0);
+        }
 
         /**
          * Create a Throttle position given a (x, y) position of the throttle and the position of the dial (z).
@@ -116,15 +127,21 @@ public class LambdaJoystick extends Joystick {
             this.x = x;
             this.y = y;
             this.z = z;
+            this.w = 0;
         }
 
         /**
-         * Create a Throttle position given a (x, y) position of the joystick throttle.
-         * @param x The right left position of the joystick (1 to -1).
-         * @param y The vertical position of the joystick, 1 forwards, -1 is backwards (1 to -1).
+         * Create a Throttle position given two joysticks (x, y) and (z, w).
+         * @param x The right left position of the first joystick (1 to -1).
+         * @param y The vertical position of the first joystick, 1 forwards, -1 is backwards (1 to -1).
+         * @param z The right left position of the second joystick (1 to -1).
+         * @param w The vertical position of the second joystick, 1 forwards, -1 is backwards (1 to -1).
          */
-        public ThrottlePosition(final double x, final double y) {
-            this(x, y, 0);
+        public ThrottlePosition(final double x, final double y, final double z, final double w) {
+            this.x = x;
+            this.y = y;
+            this.z = z;
+            this.w = w;
         }
     }
 }

--- a/src/main/java/frc/robot/MecanumDriveCustom.java
+++ b/src/main/java/frc/robot/MecanumDriveCustom.java
@@ -1,0 +1,305 @@
+/*----------------------------------------------------------------------------*/
+/* Copyright (c) 2008-2018 FIRST. All Rights Reserved.                        */
+/* Open Source Software - may be modified and shared by FRC teams. The code   */
+/* must be accompanied by the FIRST BSD license file in the root directory of */
+/* the project.                                                               */
+/*----------------------------------------------------------------------------*/
+
+//package edu.wpi.first.wpilibj.drive;
+package frc.robot;
+
+import java.util.StringJoiner;
+
+import edu.wpi.first.hal.FRCNetComm.tInstances;
+import edu.wpi.first.hal.FRCNetComm.tResourceType;
+import edu.wpi.first.hal.HAL;
+import edu.wpi.first.wpilibj.SpeedController;
+import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+
+import edu.wpi.first.wpilibj.drive.RobotDriveBase;
+import edu.wpi.first.wpilibj.drive.Vector2d;
+
+/**
+ * A class for driving Mecanum drive platforms.
+ *
+ * <p>Mecanum drives are rectangular with one wheel on each corner. Each wheel has rollers toed in
+ * 45 degrees toward the front or back. When looking at the wheels from the top, the roller axles
+ * should form an X across the robot. Each drive() function provides different inverse kinematic
+ * relations for a Mecanum drive robot.
+ *
+ * <p>Drive base diagram:
+ * <pre>
+ * \\_______/
+ * \\ |   | /
+ *   |   |
+ * /_|___|_\\
+ * /       \\
+ * </pre>
+ *
+ * <p>Each drive() function provides different inverse kinematic relations for a Mecanum drive
+ * robot. Motor outputs for the right side are negated, so motor direction inversion by the user is
+ * usually unnecessary.
+ *
+ * <p>This library uses the NED axes convention (North-East-Down as external reference in the world
+ * frame): http://www.nuclearprojects.com/ins/images/axis_big.png.
+ *
+ * <p>The positive X axis points ahead, the positive Y axis points right, and the positive Z axis
+ * points down. Rotations follow the right-hand rule, so clockwise rotation around the Z axis is
+ * positive.
+ *
+ * <p>Inputs smaller then {@value edu.wpi.first.wpilibj.drive.RobotDriveBase#kDefaultDeadband} will
+ * be set to 0, and larger values will be scaled so that the full range is still used. This
+ * deadband value can be changed with {@link #setDeadband}.
+ *
+ * <p>RobotDrive porting guide:
+ * <br>In MecanumDrive, the right side speed controllers are automatically inverted, while in
+ * RobotDrive, no speed controllers are automatically inverted.
+ * <br>{@link #driveCartesian(double, double, double, double)} is equivalent to
+ * {@link edu.wpi.first.wpilibj.RobotDrive#mecanumDrive_Cartesian(double, double, double, double)}
+ * if a deadband of 0 is used, and the ySpeed and gyroAngle values are inverted compared to
+ * RobotDrive (eg driveCartesian(xSpeed, -ySpeed, zRotation, -gyroAngle).
+ * <br>{@link #drivePolar(double, double, double)} is equivalent to
+ * {@link edu.wpi.first.wpilibj.RobotDrive#mecanumDrive_Polar(double, double, double)} if a
+ * deadband of 0 is used.
+ */
+public class MecanumDriveCustom extends RobotDriveBase {
+  private static int instances;
+
+  private final SpeedController m_frontLeftMotor;
+  private final SpeedController m_rearLeftMotor;
+  private final SpeedController m_frontRightMotor;
+  private final SpeedController m_rearRightMotor;
+
+  private double m_rightSideInvertMultiplier = -1.0;
+  private boolean m_reported;
+
+  /**
+   * Construct a MecanumDrive.
+   *
+   * <p>If a motor needs to be inverted, do so before passing it in.
+   */
+  public MecanumDriveCustom(SpeedController frontLeftMotor, SpeedController rearLeftMotor,
+                      SpeedController frontRightMotor, SpeedController rearRightMotor) {
+    verify(frontLeftMotor, rearLeftMotor, frontRightMotor, rearRightMotor);
+    m_frontLeftMotor = frontLeftMotor;
+    m_rearLeftMotor = rearLeftMotor;
+    m_frontRightMotor = frontRightMotor;
+    m_rearRightMotor = rearRightMotor;
+    addChild(m_frontLeftMotor);
+    addChild(m_rearLeftMotor);
+    addChild(m_frontRightMotor);
+    addChild(m_rearRightMotor);
+    instances++;
+    setName("MecanumDrive", instances);
+  }
+
+  /**
+   * Verifies that all motors are nonnull, throwing a NullPointerException if any of them are.
+   * The exception's error message will specify all null motors, e.g. {@code
+   * NullPointerException("frontLeftMotor, rearRightMotor")}, to give as much information as
+   * possible to the programmer.
+   *
+   * @throws NullPointerException if any of the given motors are null
+   */
+  //@SuppressWarnings({"PMD.AvoidThrowingNullPointerException", "PMD.CyclomaticComplexity"})
+  private void verify(SpeedController frontLeft, SpeedController rearLeft,
+                      SpeedController frontRight, SpeedController rearRightMotor) {
+    if (frontLeft != null && rearLeft != null && frontRight != null && rearRightMotor != null) {
+      return;
+    }
+    StringJoiner joiner = new StringJoiner(", ");
+    if (frontLeft == null) {
+      joiner.add("frontLeftMotor");
+    }
+    if (rearLeft == null) {
+      joiner.add("rearLeftMotor");
+    }
+    if (frontRight == null) {
+      joiner.add("frontRightMotor");
+    }
+    if (rearRightMotor == null) {
+      joiner.add("rearRightMotor");
+    }
+    throw new NullPointerException(joiner.toString());
+  }
+
+  /**
+   * Drive method for Mecanum platform.
+   *
+   * <p>Angles are measured clockwise from the positive X axis. The robot's speed is independent
+   * from its angle or rotation rate.
+   *
+   * @param ySpeed    The robot's speed along the Y axis [-1.0..1.0]. Right is positive.
+   * @param xSpeed    The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *                  positive.
+   */
+  //@SuppressWarnings("ParameterName")
+  public void driveCartesian(double ySpeed, double xSpeed, double zRotation) {
+    driveCartesian(ySpeed, xSpeed, zRotation, 0.0);
+  }
+
+  /**
+   * Drive method for Mecanum platform.
+   *
+   * <p>Angles are measured clockwise from the positive X axis. The robot's speed is independent
+   * from its angle or rotation rate.
+   *
+   * @param ySpeed    The robot's speed along the Y axis [-1.0..1.0]. Right is positive.
+   * @param xSpeed    The robot's speed along the X axis [-1.0..1.0]. Forward is positive.
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *                  positive.
+   * @param gyroAngle The current angle reading from the gyro in degrees around the Z axis. Use
+   *                  this to implement field-oriented controls.
+   */
+  //@SuppressWarnings("ParameterName")
+  public void driveCartesian(double ySpeed, double xSpeed, double zRotation, double gyroAngle) {
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_RobotDrive, 4,
+                 tInstances.kRobotDrive2_MecanumCartesian);
+      m_reported = true;
+    }
+
+    ySpeed = limit(ySpeed);
+    ySpeed = applyDeadband(ySpeed, m_deadband);
+
+    xSpeed = limit(xSpeed);
+    xSpeed = applyDeadband(xSpeed, m_deadband);
+
+    // Compensate for gyro angle.
+    Vector2d input = new Vector2d(ySpeed, xSpeed);
+    input.rotate(-gyroAngle);
+
+    double[] wheelSpeeds = new double[4];
+    wheelSpeeds[MotorType.kFrontLeft.value]  =  input.x + input.y + zRotation;
+    wheelSpeeds[MotorType.kFrontRight.value] =  input.x + input.y - zRotation;
+    wheelSpeeds[MotorType.kRearLeft.value]   = -input.x + input.y + zRotation;
+    wheelSpeeds[MotorType.kRearRight.value]  = -input.x + input.y - zRotation;
+
+    normalize(wheelSpeeds);
+
+    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft.value] * m_maxOutput);
+    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight.value] * m_maxOutput
+        * m_rightSideInvertMultiplier);
+    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft.value] * m_maxOutput);
+    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight.value] * m_maxOutput
+        * m_rightSideInvertMultiplier);
+
+    feed();
+  }
+
+  public void driveCartesian(double ySpeed, double xSpeed, double zSpeed, double wSpeed, double gyroAngle) {
+       
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_RobotDrive, 4,
+                 tInstances.kRobotDrive2_MecanumCartesian);
+      m_reported = true;
+    }
+
+    ySpeed = limit(ySpeed);
+    ySpeed = applyDeadband(ySpeed, m_deadband);
+
+    xSpeed = limit(xSpeed);
+    xSpeed = applyDeadband(xSpeed, m_deadband);
+
+    zSpeed = limit(zSpeed);
+    zSpeed = applyDeadband(zSpeed, m_deadband);
+
+    wSpeed = limit(wSpeed);
+    wSpeed = applyDeadband(wSpeed, m_deadband);
+
+    // Compensate for gyro angle.
+    Vector2d input = new Vector2d(ySpeed, xSpeed);
+    input.rotate(-gyroAngle);
+
+    double[] wheelSpeeds = new double[4];
+    wheelSpeeds[MotorType.kFrontLeft.value]  =  input.x + input.y + wSpeed;
+    wheelSpeeds[MotorType.kFrontRight.value] =  input.x + input.y - wSpeed;
+    wheelSpeeds[MotorType.kRearLeft.value]   = -input.x + input.y + wSpeed;
+    wheelSpeeds[MotorType.kRearRight.value]  = -input.x + input.y - wSpeed;
+
+    normalize(wheelSpeeds);
+
+    m_frontLeftMotor.set(wheelSpeeds[MotorType.kFrontLeft.value] * m_maxOutput);
+    m_frontRightMotor.set(wheelSpeeds[MotorType.kFrontRight.value] * m_maxOutput
+        * m_rightSideInvertMultiplier);
+    m_rearLeftMotor.set(wheelSpeeds[MotorType.kRearLeft.value] * m_maxOutput);
+    m_rearRightMotor.set(wheelSpeeds[MotorType.kRearRight.value] * m_maxOutput
+        * m_rightSideInvertMultiplier);
+
+    feed();
+  }
+
+  /**
+   * Drive method for Mecanum platform.
+   *
+   * <p>Angles are measured counter-clockwise from straight ahead. The speed at which the robot
+   * drives (translation) is independent from its angle or rotation rate.
+   *
+   * @param magnitude The robot's speed at a given angle [-1.0..1.0]. Forward is positive.
+   * @param angle     The angle around the Z axis at which the robot drives in degrees [-180..180].
+   * @param zRotation The robot's rotation rate around the Z axis [-1.0..1.0]. Clockwise is
+   *                  positive.
+   */
+  //@SuppressWarnings("ParameterName")
+  public void drivePolar(double magnitude, double angle, double zRotation) {
+    if (!m_reported) {
+      HAL.report(tResourceType.kResourceType_RobotDrive, 4, tInstances.kRobotDrive2_MecanumPolar);
+      m_reported = true;
+    }
+
+    driveCartesian(magnitude * Math.sin(angle * (Math.PI / 180.0)),
+                   magnitude * Math.cos(angle * (Math.PI / 180.0)), zRotation, 0.0);
+  }
+
+  /**
+   * Gets if the power sent to the right side of the drivetrain is multipled by -1.
+   *
+   * @return true if the right side is inverted
+   */
+  public boolean isRightSideInverted() {
+    return m_rightSideInvertMultiplier == -1.0;
+  }
+
+  /**
+   * Sets if the power sent to the right side of the drivetrain should be multipled by -1.
+   *
+   * @param rightSideInverted true if right side power should be multipled by -1
+   */
+  public void setRightSideInverted(boolean rightSideInverted) {
+    m_rightSideInvertMultiplier = rightSideInverted ? -1.0 : 1.0;
+  }
+
+  @Override
+  public void stopMotor() {
+    m_frontLeftMotor.stopMotor();
+    m_frontRightMotor.stopMotor();
+    m_rearLeftMotor.stopMotor();
+    m_rearRightMotor.stopMotor();
+    feed();
+  }
+
+  @Override
+  public String getDescription() {
+    return "MecanumDrive";
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    builder.setSmartDashboardType("MecanumDrive");
+    builder.setActuator(true);
+    builder.setSafeState(this::stopMotor);
+    builder.addDoubleProperty("Front Left Motor Speed",
+        m_frontLeftMotor::get,
+        m_frontLeftMotor::set);
+    builder.addDoubleProperty("Front Right Motor Speed",
+        () -> m_frontRightMotor.get() * m_rightSideInvertMultiplier,
+        value -> m_frontRightMotor.set(value * m_rightSideInvertMultiplier));
+    builder.addDoubleProperty("Rear Left Motor Speed",
+        m_rearLeftMotor::get,
+        m_rearLeftMotor::set);
+    builder.addDoubleProperty("Rear Right Motor Speed",
+        () -> m_rearRightMotor.get() * m_rightSideInvertMultiplier,
+        value -> m_rearRightMotor.set(value * m_rightSideInvertMultiplier));
+  }
+}

--- a/src/main/java/frc/robot/MecanumDriveTrain.java
+++ b/src/main/java/frc/robot/MecanumDriveTrain.java
@@ -2,14 +2,17 @@ package frc.robot;
 
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkMaxLowLevel.MotorType;
-import edu.wpi.first.wpilibj.drive.MecanumDrive; 
+import frc.robot.MecanumDriveCustom;
+//import edu.wpi.first.wpilibj.drive.MecanumDrive; 
 import frc.robot.LambdaJoystick.ThrottlePosition;
 
 public class MecanumDriveTrain {
-    private static final int kFrontLeftChannel = 2;
-    private static final int kRearLeftChannel = 3;
-    private static final int kFrontRightChannel = 1;
-    private static final int kRearRightChannel = 0;
+    private static final int kFrontLeftChannel = 1;
+    
+    //JAG - chnaged mmotor 0 to motor 4
+    private static final int kRearLeftChannel = 4;
+    private static final int kFrontRightChannel = 3;
+    private static final int kRearRightChannel = 2;
 
     private CANSparkMax frontLeft;
     private CANSparkMax rearLeft;
@@ -18,7 +21,7 @@ public class MecanumDriveTrain {
 
     private boolean driveInverted = false;
 
-    private MecanumDrive m_robotDrive;
+    private MecanumDriveCustom m_robotDrive;
 
     public MecanumDriveTrain() {
         frontLeft = new CANSparkMax(kFrontLeftChannel, MotorType.kBrushless); 
@@ -30,10 +33,10 @@ public class MecanumDriveTrain {
         frontLeft.setInverted(true);
         rearLeft.setInverted(true);
 
-        m_robotDrive = new MecanumDrive(frontLeft, rearLeft, frontRight, rearRight);
+        m_robotDrive = new MecanumDriveCustom(frontLeft, rearLeft, frontRight, rearRight);
     }
 
-    public MecanumDrive getRobotDrive() {return m_robotDrive;}
+    public MecanumDriveCustom getRobotDrive() {return m_robotDrive;}
 
     public void invertDrive() {
         driveInverted = !driveInverted;
@@ -41,12 +44,14 @@ public class MecanumDriveTrain {
 
     public void updateSpeed(final ThrottlePosition throttlePos) {
         //double ySpeed, double xSpeed, double zRotation, double gyroAngle
-        //z should make it turn, rest should 
-        if (driveInverted) {
-            m_robotDrive.driveCartesian(-throttlePos.y, -throttlePos.x, -throttlePos.z, 0); //gyro angle where 0 is
+        //z sho+ uld make it turn, rest should 
+       
+       
+       if (driveInverted) {
+            m_robotDrive.driveCartesian(-throttlePos.y, -throttlePos.x, -throttlePos.z, -throttlePos.w, 0); //gyro angle where 0 is
         } else {
-            m_robotDrive.driveCartesian(throttlePos.y, throttlePos.x, throttlePos.z, 0); //gyro angle where 0 is
+            m_robotDrive.driveCartesian(throttlePos.y, throttlePos.x, throttlePos.z, throttlePos.w, 0); //gyro angle where 0 is
         }
         
     } //Might not be needed, just depends on if we want to use Lambda joystick
-} 
+}   

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -9,7 +9,8 @@ package frc.robot;
 
 import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj.TimedRobot;
-import edu.wpi.first.wpilibj.drive.MecanumDrive;
+import frc.robot.MecanumDriveCustom;
+//import edu.wpi.first.wpilibj.drive.MecanumDrive;
 
 /**
  * This is a demo program showing how to use Mecanum control with the RobotDrive
@@ -19,7 +20,7 @@ public class Robot extends TimedRobot {
   private static final int kJoystickChannel = 0;
 
   private final MecanumDriveTrain mecanum = new MecanumDriveTrain();
-  private final MecanumDrive m_robotDrive = mecanum.getRobotDrive();
+  private final MecanumDriveCustom m_robotDrive = mecanum.getRobotDrive();
   private final LambdaJoystick joystick1 = new LambdaJoystick(0, mecanum::updateSpeed);
   private final LambdaJoystick joystick2 = new LambdaJoystick(1, mecanum::updateSpeed);   //TODO filler
 


### PR DESCRIPTION
Alex and Jacob helped fix a thing where the Y axis wasn't eliciting the response from the motors we wanted, we ended up fixing it by fixing two values FIRST mecanum class (which i stand by the fact is wrong given the context of the rest of the code (or the rest of the code was wrong, but honestly which is easier to fix?)) and we did this by making our own custom class and replacing all instance of FIRST's Class in the code with ours

There were similar but completely unrelated problem with the (Z, Z Rotate) plane where the Z rotate is the vertical axis, so (and I didn't personally make these changes nor did personally test them) it was decided to modify lambda joystick class to include 4 axis, the 4th being called 'w',  and then call the 4th one in the mecanum code. So this apparently worked and fixed the problem, but resulted in the code confusing the two joysticks and talking input of one plane form one and the other plane form the other. I am working on fixing that problem and will include comments in my next pull request, however what I heard of the testing confirms my hypothesis that the way lambda joystick works is it takes the first 3 axis on the joystick, and labels them X,Y,Z regardless of what they actually are. On an Attack 3, our normal joystick, this works fine because there is in fact only an X,Y,Z. But on joy sticks with a Z Rotate, where the Z rotate can be either the third or the fourth axis depending on the specific controller, the code will always treat the third one a Z, even if it's actually the Z rotate or X2. 

We also added a diagnostic print statment to figure out how lambda was handling the joystick inputs